### PR TITLE
Introduce failing test for flattened enums

### DIFF
--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -444,3 +444,35 @@ fn ser_de_field_vec_tuple() {
 
     test_ser_de_eq(foo);
 }
+
+#[test]
+fn ser_de_flattened_enum() {
+    #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+    struct KrpcMessage {
+        message_type: MessageType,
+    }
+
+    #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+    enum MessageType {
+        Query,
+        Response,
+    }
+
+    #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+    struct KrpcResponse {
+        #[serde(flatten)]
+        krpc: KrpcMessage,
+    }
+
+    // Passes
+    test_ser_de_eq(KrpcMessage {
+        message_type: MessageType::Response,
+    });
+
+    // Fails
+    test_ser_de_eq(KrpcResponse {
+        krpc: KrpcMessage {
+            message_type: MessageType::Response,
+        },
+    });
+}


### PR DESCRIPTION
From: https://github.com/toby/serde-bencode/pull/31#issue-1448971290
By: [nrempel](https://github.com/nrempel)

```
Hello,

This pull request adds a failing test for deserializing flattened structs containing enums.

Is it expected that this test should pass or is there some serde caveat that I'm unaware of here? I'm happy to take a crack at fixing this if it's fixable. Any pointers would be appreciated.

Thanks.
```