### PR TITLE
Add cargo-fuzz fuzzer

### DIFF
--- a/fuzz/.gitignore
+++ b/fuzz/.gitignore
@@ -1,0 +1,3 @@
+target
+corpus
+artifacts

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "serde_bencode-fuzz"
+version = "0.0.0"
+authors = ["Automatically generated"]
+publish = false
+edition = "2018"
+
+[package.metadata]
+cargo-fuzz = true
+
+[dependencies]
+libfuzzer-sys = "0.4"
+
+[dependencies.serde_bencode]
+path = ".."
+
+# Prevent this from interfering with workspaces
+[workspace]
+members = ["."]
+
+[[bin]]
+name = "from_bytes"
+path = "fuzz_targets/from_bytes.rs"
+test = false
+doc = false

--- a/fuzz/fuzz_targets/from_bytes.rs
+++ b/fuzz/fuzz_targets/from_bytes.rs
@@ -1,0 +1,9 @@
+#![no_main]
+use libfuzzer_sys::fuzz_target;
+
+use serde_bencode::value::Value;
+use serde_bencode::from_bytes;
+
+fuzz_target!(|data: &[u8]| {
+    let _: Result<Value, _> = from_bytes(data);
+});


### PR DESCRIPTION
From: https://github.com/toby/serde-bencode/pull/29
By: [5225225](https://github.com/5225225)

`This adds a https://github.com/rust-fuzz/cargo-fuzz fuzzer which I used to find #28`